### PR TITLE
docs: clarify client API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,12 @@ MAX_UPLOAD_SIZE_MB=500
 
 ### Client `.env`
 ```env
-VITE_API_URL=http://localhost:4000/api
+VITE_API_URL=http://localhost:4000
 VITE_STREAMING_URL=http://localhost:4000/stream
 VITE_CHUNK_SIZE_MB=5
 ```
+
+> **Note:** The frontend automatically prefixes API requests with `/api/…`. Supplying a base URL that already ends with `/api` will cause requests like `/api/api/auth/login`, which the server rejects with "Route not found" errors during login.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the client `.env` example to use the bare server origin for `VITE_API_URL`
- note that the frontend already prefixes requests with `/api/…`, and duplicating `/api` causes route-not-found errors

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cd76044438832db6cfeb8bfe415c40