### PR TITLE
Use n118 SSM parameters only

### DIFF
--- a/video-webapp/server/src/config.js
+++ b/video-webapp/server/src/config.js
@@ -115,14 +115,14 @@ export async function loadConfig () {
       limitFileSize,
       presignedTtl
     ] = await Promise.all([
-      loadParameterAny(['/a2/s3_bucket', '/n11817143/app/s3Bucket']),
-      loadParameterAny(['/a2/dynamo_table', '/n11817143/app/dynamoTable']),
-      loadParameterAny(['/a2/dynamo_owner_index', '/n11817143/app/dynamoOwnerIndex']),
+      loadParameter('/n11817143/app/s3Bucket'),
+      loadParameter('/n11817143/app/dynamoTable'),
+      loadParameter('/n11817143/app/dynamoOwnerIndex'),
       loadParameter('/n11817143/app/s3_raw_prefix'),
       loadParameter('/n11817143/app/s3_transcoded_prefix'),
       loadParameter('/n11817143/app/s3_thumbnail_prefix'),
-      loadParameterAny(['/a2/limit_file_size_mb', '/n11817143/app/maxUploadSizeMb']),
-      loadParameterAny(['/a2/presigned_ttl_seconds', '/n11817143/app/preSignedUrlTTL'])
+      loadParameter('/n11817143/app/maxUploadSizeMb'),
+      loadParameter('/n11817143/app/preSignedUrlTTL')
     ]);
 
     const secretValues = await loadSecret('n11817143-a2-secret');


### PR DESCRIPTION
## Summary
- update configuration loading to rely exclusively on the `/n11817143/app` SSM parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76cd964b0832da3bd2a9f65fd7165