### PR TITLE
Add local backend defaults for docker compose

### DIFF
--- a/video-webapp/docker-compose.yml
+++ b/video-webapp/docker-compose.yml
@@ -7,6 +7,17 @@ services:
     environment:
       - AWS_REGION=${AWS_REGION:-ap-southeast-2}
       - CLIENT_ORIGINS=${CLIENT_ORIGINS:-http://localhost:5173}
+      - S3_BUCKET=${S3_BUCKET:-local-video-bucket}
+      - DYNAMO_TABLE=${DYNAMO_TABLE:-LocalVideos}
+      - DYNAMO_OWNER_INDEX=${DYNAMO_OWNER_INDEX:-OwnerIndex}
+      - COGNITO_USER_POOL_ID=${COGNITO_USER_POOL_ID:-ap-southeast-2_CdVnmKfrW}
+      - COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID:-11pap5u5svkhr1hgjf934sj0id}
+      - S3_RAW_PREFIX=${S3_RAW_PREFIX:-raw-videos/}
+      - S3_TRANSCODED_PREFIX=${S3_TRANSCODED_PREFIX:-transcoded-videos/}
+      - S3_THUMBNAIL_PREFIX=${S3_THUMBNAIL_PREFIX:-thumbnails/}
+      - PRESIGNED_TTL_SECONDS=${PRESIGNED_TTL_SECONDS:-900}
+      - LIMIT_FILE_SIZE_MB=${LIMIT_FILE_SIZE_MB:-512}
+      - JWT_SECRET=${JWT_SECRET:-video-webapp-dev-secret}
     networks:
       - appnet
 


### PR DESCRIPTION
## Summary
- provide default environment variables for the backend in docker-compose so it can boot without AWS Parameter Store

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76f6393c4832d8c83cb19ea2eeee8