### PR TITLE
Enable AWS service mode configuration and cache endpoint

### DIFF
--- a/video-webapp/README.md
+++ b/video-webapp/README.md
@@ -47,6 +47,7 @@ Cognito Hosted UI / Amplify Auth
    - `/n11817143/app/presignTTL` → `900`
    - `/n11817143/app/cognitoUserPoolId` → `ap-southeast-2_CdVnmKfrW`
    - `/n11817143/app/cognitoClientId` → `11pap5u5svkhr1hgjf934sj0id`
+   - `/n11817143/app/cacheEndpoint` → `n11817143-a2-cache.km2ji.cfg.apse2.cache.amazonaws.com:11211`
 5. **Secrets Manager secret** `n11817143-a2-secret` (JSON) containing sensitive runtime configuration. Example payload:
    ```json
    {
@@ -91,6 +92,7 @@ At minimum set:
 - `AWS_REGION` or `AWS_DEFAULT_REGION`
 - `CLIENT_ORIGINS` (comma-separated list including your frontend origin, e.g. `https://myvideoapp.example.com`)
 - Frontend `.env`: `VITE_API_URL`, `VITE_AWS_REGION`, `VITE_COGNITO_USER_POOL_ID`, `VITE_COGNITO_CLIENT_ID`
+- Backend `.env`: set `USE_DEV_SERVICES=true` when developing locally to avoid calling AWS. Leave it unset/false on AWS so the real services are used. Provide `CACHE_ENDPOINT` or `MEMCACHED_ENDPOINT` if the ElastiCache cluster uses a different hostname.
 
 ## Running Locally
 

--- a/video-webapp/docs/aws-assignment-2.md
+++ b/video-webapp/docs/aws-assignment-2.md
@@ -45,5 +45,6 @@ This document captures the deployed AWS resources and runtime configuration for 
 | `/n11817143/app/s3_transcoded_prefix` | S3 prefix for transcoded assets |
 | `/n11817143/app/maxUploadSizeMb` | Upload file size limit in megabytes |
 | `/n11817143/app/preSignedUrlTTL` | Signed URL TTL (seconds) |
+| `/n11817143/app/cacheEndpoint` | ElastiCache Memcached endpoint |
 
 These values are read automatically by `server/src/config.js` during startup. Environment variables can still override them when required (see `server/.env.example`).

--- a/video-webapp/server/.env.example
+++ b/video-webapp/server/.env.example
@@ -5,6 +5,12 @@ CLIENT_ORIGINS=http://n11817143-videoapp.cab432.com
 # AWS SDK region
 AWS_REGION=ap-southeast-2
 
+# Toggle development stubs (set to true locally to avoid AWS calls)
+USE_DEV_SERVICES=true
+
+# Optional ElastiCache endpoint override for AWS deployments
+# CACHE_ENDPOINT=n11817143-a2-cache.km2ji.cfg.apse2.cache.amazonaws.com:11211
+
 # AWS service bindings
 S3_BUCKET=n11817143-a2
 DYNAMO_TABLE=VideoMetadata

--- a/video-webapp/server/src/aws/cache.js
+++ b/video-webapp/server/src/aws/cache.js
@@ -1,18 +1,35 @@
 import memjs from 'memjs';
 import { getConfig } from '../config.js';
+import { useAwsServices } from '../utils/runtime.js';
 
 // Development cache - in-memory storage
 const devCache = new Map();
 
-const hasAwsCredentials = () => {
-  // Force development mode
-  return false;
+let cacheClient = null;
+
+const getCacheClient = () => {
+  if (!useAwsServices()) {
+    return null;
+  }
+  if (!cacheClient) {
+    const config = getConfig();
+    const endpoint = process.env.MEMCACHED_ENDPOINT
+      || process.env.CACHE_ENDPOINT
+      || config.CACHE_ENDPOINT;
+
+    if (!endpoint) {
+      console.warn('CACHE_ENDPOINT not configured. Falling back to in-memory cache.');
+      cacheClient = null;
+      return null;
+    }
+
+    cacheClient = memjs.Client.create(endpoint);
+  }
+  return cacheClient;
 };
 
-export const cache = memjs.Client.create('n11817143-a2-cache.km2ji.cfg.apse2.cache.amazonaws.com:11211');
-
 export async function cacheGet (key) {
-  if (!hasAwsCredentials()) {
+  if (!useAwsServices()) {
     // Development mode - use in-memory cache
     const cached = devCache.get(key);
     if (cached && cached.expires > Date.now()) {
@@ -23,6 +40,10 @@ export async function cacheGet (key) {
   }
 
   try {
+    const cache = getCacheClient();
+    if (!cache) {
+      return null;
+    }
     const res = await cache.get(key);
     return res.value ? JSON.parse(res.value.toString()) : null;
   } catch (error) {
@@ -32,7 +53,7 @@ export async function cacheGet (key) {
 }
 
 export async function cacheSet (key, value, ttl = 300) {
-  if (!hasAwsCredentials()) {
+  if (!useAwsServices()) {
     // Development mode - use in-memory cache
     devCache.set(key, {
       value,
@@ -42,6 +63,10 @@ export async function cacheSet (key, value, ttl = 300) {
   }
 
   try {
+    const cache = getCacheClient();
+    if (!cache) {
+      return;
+    }
     await cache.set(key, JSON.stringify(value), { expires: ttl });
   } catch (error) {
     console.warn(`Cache set failed for key ${key}:`, error.message);

--- a/video-webapp/server/src/aws/clients.js
+++ b/video-webapp/server/src/aws/clients.js
@@ -3,31 +3,26 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { fromSSO } from '@aws-sdk/credential-providers';
 import { getConfig } from '../config.js';
+import { useAwsServices } from '../utils/runtime.js';
 
 let s3Client;
 let dynamoClient;
 let documentClient;
-
-// Check if we have AWS credentials
-const hasAwsCredentials = () => {
-  // Check if AWS_PROFILE is set for SSO authentication
-  return !!process.env.AWS_PROFILE;
-};
 
 // Create AWS configuration with SSO credentials
 const getAwsConfig = () => {
   const config = getConfig();
   return {
     region: config.REGION,
-    credentials: process.env.AWS_PROFILE ? 
-      fromSSO({ profile: process.env.AWS_PROFILE }) : 
+    credentials: process.env.AWS_PROFILE ?
+      fromSSO({ profile: process.env.AWS_PROFILE }) :
       undefined
   };
 };
 
 export const getS3Client = () => {
-  if (!hasAwsCredentials()) {
-    throw new Error('AWS credentials not configured - running in development mode');
+  if (!useAwsServices()) {
+    throw new Error('AWS services disabled - enable USE_DEV_SERVICES=false to access AWS.');
   }
   if (!s3Client) {
     s3Client = new S3Client(getAwsConfig());
@@ -36,8 +31,8 @@ export const getS3Client = () => {
 };
 
 export const getDynamoClient = () => {
-  if (!hasAwsCredentials()) {
-    throw new Error('AWS credentials not configured - running in development mode');
+  if (!useAwsServices()) {
+    throw new Error('AWS services disabled - enable USE_DEV_SERVICES=false to access AWS.');
   }
   if (!dynamoClient) {
     dynamoClient = new DynamoDBClient(getAwsConfig());
@@ -46,8 +41,8 @@ export const getDynamoClient = () => {
 };
 
 export const getDocumentClient = () => {
-  if (!hasAwsCredentials()) {
-    throw new Error('AWS credentials not configured - running in development mode');
+  if (!useAwsServices()) {
+    throw new Error('AWS services disabled - enable USE_DEV_SERVICES=false to access AWS.');
   }
   if (!documentClient) {
     documentClient = DynamoDBDocumentClient.from(getDynamoClient(), {

--- a/video-webapp/server/src/utils/runtime.js
+++ b/video-webapp/server/src/utils/runtime.js
@@ -1,0 +1,29 @@
+const truthyValues = new Set(['1', 'true', 'yes', 'y', 'on']);
+const falsyValues = new Set(['0', 'false', 'no', 'n', 'off']);
+
+function parseBoolean (value, defaultValue = false) {
+  if (value == null) return defaultValue;
+  const normalized = `${value}`.trim().toLowerCase();
+  if (truthyValues.has(normalized)) return true;
+  if (falsyValues.has(normalized)) return false;
+  return defaultValue;
+}
+
+export function useDevelopmentServices () {
+  if (process.env.FORCE_DEV_MODE != null) {
+    return parseBoolean(process.env.FORCE_DEV_MODE, false);
+  }
+  if (process.env.USE_DEV_SERVICES != null) {
+    return parseBoolean(process.env.USE_DEV_SERVICES, false);
+  }
+  if (process.env.NODE_ENV === 'test') {
+    return true;
+  }
+  return false;
+}
+
+export function useAwsServices () {
+  return !useDevelopmentServices();
+}
+
+export default { useDevelopmentServices, useAwsServices };

--- a/video-webapp/server/src/videos/video.controller.js
+++ b/video-webapp/server/src/videos/video.controller.js
@@ -13,27 +13,22 @@ import {
   devListVideos,
   devGetVideo,
   devDeleteVideo,
-  devUpdateVideo,
   devGetPresignedUrl
 } from './dev-video.service.js';
 import { AppError } from '../utils/errors.js';
 import { getConfig } from '../config.js';
 import { cacheGet, cacheSet } from '../aws/cache.js';
+import { useAwsServices } from '../utils/runtime.js';
 
-// Check if AWS is configured properly (avoid trying to use AWS services)
-const hasAwsCredentials = () => {
-  const config = getConfig();
-  // Return false to force development mode since we don't have AWS credentials
-  return false; // Always use development mode for now
-};
+const shouldUseAws = () => useAwsServices();
 
 export const uploadVideo = async (req, res) => {
-  if (!hasAwsCredentials()) {
+  if (!shouldUseAws()) {
     console.log('🚧 Using development video upload');
     const video = await devUploadVideo(req.user.id, req.file);
     return res.status(201).json({ videoId: video.id, video });
   }
-  
+
   const videoId = await handleUpload(req.user.id, req.file);
   res.status(201).json({ videoId });
 };
@@ -43,18 +38,18 @@ export const listUserVideos = async (req, res) => {
   const rawLimit = Number.parseInt(req.query.limit || '10', 10);
   const limit = Math.min(Math.max(rawLimit || 10, 1), 50);
   
-  if (!hasAwsCredentials()) {
+  if (!shouldUseAws()) {
     console.log('🚧 Using development video listing');
     const result = await devListVideos(req.user.id, page, limit);
     return res.json({ page, limit, ...result });
   }
-  
+
   const result = await listVideos(req.user.id, page, limit);
   res.json({ page, limit, ...result });
 };
 
 export const getVideo = async (req, res) => {
-  if (!hasAwsCredentials()) {
+  if (!shouldUseAws()) {
     console.log('🚧 Using development video get');
     const video = await devGetVideo(req.params.id, req.user.id);
     return res.json({ video });
@@ -73,6 +68,9 @@ export const getVideo = async (req, res) => {
 };
 
 export const streamVideo = async (req, res) => {
+  if (!shouldUseAws()) {
+    return res.status(501).json({ message: 'Video streaming is unavailable in development mode' });
+  }
   const variant = req.query.variant === 'transcoded' ? 'transcoded' : 'original';
   const download = req.query.download === '1' || req.query.download === 'true';
   const range = req.headers.range || null;
@@ -87,6 +85,9 @@ export const streamVideo = async (req, res) => {
 };
 
 export const requestTranscode = async (req, res) => {
+  if (!shouldUseAws()) {
+    return res.status(501).json({ message: 'Transcoding is unavailable in development mode' });
+  }
   const preset = (req.validatedBody?.preset || '720p').toLowerCase();
   const { FFMPEG_PRESETS } = getConfig();
   if (!FFMPEG_PRESETS?.[preset]) {
@@ -98,23 +99,31 @@ export const requestTranscode = async (req, res) => {
 };
 
 export const serveThumbnail = async (req, res) => {
+  if (!shouldUseAws()) {
+    const video = await devGetVideo(req.params.id, req.user.id);
+    return res.redirect(`/dev-storage/thumbnails/${video.id}-thumb.jpg`);
+  }
   const video = await getVideoByIdForUser(req.params.id, req.user.id);
   const url = await getThumbnailUrl(video);
   res.redirect(url);
 };
 
 export const removeVideo = async (req, res) => {
+  if (!shouldUseAws()) {
+    await devDeleteVideo(req.params.id, req.user.id);
+    return res.json({ message: 'Video deleted' });
+  }
   const video = await getVideoByIdForUser(req.params.id, req.user.id);
   await deleteVideo(video);
   res.json({ message: 'Video deleted' });
 };
 
 export const getPresignedDownload = async (req, res) => {
-  if (!hasAwsCredentials()) {
+  if (!shouldUseAws()) {
     console.log('🚧 Using development presigned URL');
     const variant = req.validatedQuery?.variant || 'original';
     const download = req.validatedQuery?.download ?? true;
-    
+
     try {
       const payload = await devGetPresignedUrl(req.params.id, req.user.id, variant, download);
       return res.json(payload);


### PR DESCRIPTION
## Summary
- add a runtime helper to toggle between AWS integrations and local development stubs
- update backend services to honour the AWS mode flag, use real AWS clients, and support configurable cache endpoints
- document the new configuration in the README, deployment inventory, and `.env` example

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b28b4f2c832d987198019ec7300b